### PR TITLE
[628] Stripe subscription cancelled

### DIFF
--- a/src/main/java/tech/zerofiltre/blog/infra/providers/api/stripe/SubscriptionEventHandler.java
+++ b/src/main/java/tech/zerofiltre/blog/infra/providers/api/stripe/SubscriptionEventHandler.java
@@ -48,7 +48,6 @@ public class SubscriptionEventHandler {
 
         SubscriptionRetrieveParams subscriptionRetrieveParams = SubscriptionRetrieveParams.builder()
                 .addExpand("customer")
-                .addExpand("data.plan.product")
                 .build();
         subscription = Subscription.retrieve(subscription.getId(), subscriptionRetrieveParams, null);
 


### PR DESCRIPTION
On s'est rendu compte qu'en utilisant "addExpand" pour une requête Stripe permet de retourner l'objet en entier et pas seulement l'id.
On a besoin de récupérer l'id de product et non l'objet "product".